### PR TITLE
Remove unnecessary migration file for Pieces table

### DIFF
--- a/db/migrate/20160927192517_change_column_name_pieces.rb
+++ b/db/migrate/20160927192517_change_column_name_pieces.rb
@@ -1,5 +1,0 @@
-class ChangeColumnNamePieces < ActiveRecord::Migration
-  def change
-  	rename_column :pieces, :piece_name, :type
-  end
-end


### PR DESCRIPTION
Removes migration file that unnecessarily changes a column name on the Pieces table (and caused Heroku build failure).
